### PR TITLE
Remove CSV header line from the data dump

### DIFF
--- a/openshift-crc/deploy.yaml
+++ b/openshift-crc/deploy.yaml
@@ -84,7 +84,7 @@ objects:
                 set -e;
                 for table in $TABLES; do
                   echo "Table '${table}': Data collection started.";
-                  psql -h $PGHOST -p $PGPORT -U $PGUSER $PGDATABASE -c "COPY $table TO STDOUT WITH CSV HEADER" |
+                  psql -h $PGHOST -p $PGPORT -U $PGUSER $PGDATABASE -c "COPY $table TO STDOUT CSV" |
                   gzip -9 |
                   aws s3 cp - ${S3_OUTPUT}/$(date -I)/${table}.csv.gz;
                   echo "Table '${table}': Dump uploaded to intermediate storage.";


### PR DESCRIPTION
Remove header line from CSV dumps

Just replace `s/"WITH CSV HEADER"/CSV/` in the job's `psql` query:

### Before
```sh
$ psql sampledb -c "COPY subscription_capacity TO STDOUT WITH CSV HEADER;" | head -5

product_id,account_number,subscription_id,owner_id,physical_sockets,virtual_sockets,has_unlimited_guest_sockets,begin_date,end_date
product_1,account_1,sub_1,owner_1,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
product_2,account_2,sub_2,owner_2,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
product_3,account_3,sub_3,owner_3,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
product_4,account_4,sub_4,owner_4,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
```

### After
```sh
$ psql sampledb -c "COPY subscription_capacity TO STDOUT CSV;" | head -5

product_1,account_1,sub_1,owner_1,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
product_2,account_2,sub_2,owner_2,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
product_3,account_3,sub_3,owner_3,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
product_4,account_4,sub_4,owner_4,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
product_5,account_5,sub_5,owner_5,1,2,t,2019-11-24 00:00:00+00,2019-11-25 16:16:02.420845+00
```

cc @accorvin